### PR TITLE
ci: opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: "pages"
   cancel-in-progress: false


### PR DESCRIPTION
Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to suppress the Node.js 20 deprecation warning for actions/checkout, actions/configure-pages, and actions/upload-pages-artifact. Node.js 24 becomes the default on June 2, 2026.

https://claude.ai/code/session_01C1MTLcWno26QmBdy1xRiPK